### PR TITLE
Ensure the port is an integer when non-standard

### DIFF
--- a/async_urequests.py
+++ b/async_urequests.py
@@ -124,6 +124,7 @@ async def _request_raw(method, url, headers, data, json):
             ssl = False
         else:
             raise ValueError("Unsupported protocol: %s" % (proto))
+        port = int(port)
     except ValueError:
         if proto == "http:":
             port = 80


### PR DESCRIPTION
This is a simple little fix for non-standard ports to ensure that they're an integer not a string