### PR TITLE
Update ussl to ssl

### DIFF
--- a/async_urequests.py
+++ b/async_urequests.py
@@ -103,8 +103,8 @@ async def open_connection(host, port, ssl):
             raise er
     yield core._io_queue.queue_write(s)
     if ssl:
-        import ussl
-        s = ussl.wrap_socket(s, server_hostname=host) # WARNING, this blocks for a long time
+        import ssl
+        s = ssl.wrap_socket(s, server_hostname=host) # WARNING, this blocks for a long time
     yield core._io_queue.queue_write(s)
     ss = Stream(s)
     return ss, ss


### PR DESCRIPTION
from Micropython 1.23 a switch was made to use ssl module (https://github.com/orgs/micropython/discussions/15172).
The current code leads to the message 'no module named ussl', this change resolves that issue.  
Note that neither actually verifies TLS certificates